### PR TITLE
Enable manual publish from GH ui

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,6 +2,7 @@ name: Publish Package to npmjs
 on:
   release:
     types: [published]
+  workflow_dispatch:
 jobs:
   npm-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

Sometimes we want to manually publish a new patch version without creating a release (use case: fixing a typo in the readme published on npm).

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Manual on my project (https://github.com/rphlmr/comply/actions/runs/11082428245)

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [x] Check if the UI is working as expected and is satisfactory
- [x] Check if the code is well documented
- [x] Check if the behavior is what is expected
- [x] Check if the code is well tested
- [x] Check if the code is readable and well formatted
- [x] Additional checks (document below if any)

# Screenshots (if appropriate):

<img width="928" alt="image" src="https://github.com/user-attachments/assets/b8299190-2cac-4cb2-8ab8-a833de5d51fe">


# Questions (if appropriate):
